### PR TITLE
Update packages on Server STOP

### DIFF
--- a/packages/server.yaml
+++ b/packages/server.yaml
@@ -95,6 +95,19 @@ group:
     entities: []
 
 automation:
+    # Update Packages on server STOP
+  - id: 'update_on_server_stop'
+    alias: "|| Update Packages on STOP"
+    description: ''
+    trigger:
+    - platform: homeassistant
+      event: shutdown
+    condition: []
+    action:
+    - service: script.turn_on
+      target:
+        entity_id: script.update_packages
+    mode: single
     # Notify on server start using defined service
   - id: 'server_start'
     alias: "|| Server Start"


### PR DESCRIPTION
Add automation to download packages before server STOP and in this way on every reboot you have the lastest packages. One note the update does not show in logs but the files are updated.