### PR TITLE
Labels instead of helpers and general notify helper

### DIFF
--- a/packages/asuswrt.yaml
+++ b/packages/asuswrt.yaml
@@ -36,6 +36,8 @@ automation:
       - service: >-
           {% if states.input_text.notify_service_server.state is defined %}
             {% set notify_service = states('input_text.notify_service_server') %}
+          {% elif states.input_text.notify_service.state is defined %}
+            {% set notify_service = states('input_text.notify_service') %}
           {% else %}
             {% set notify_service = 'notify' %}
           {% endif %}
@@ -46,6 +48,8 @@ automation:
       - service: >-
           {% if states.input_text.notify_service_server.state is defined %}
             {% set notify_service = states('input_text.notify_service_server') %}
+          {% elif states.input_text.notify_service.state is defined %}
+            {% set notify_service = states('input_text.notify_service') %}
           {% else %}
             {% set notify_service = 'notify' %}
           {% endif %}
@@ -68,6 +72,8 @@ automation:
       - service: >-
           {% if states.input_text.notify_service_server.state is defined %}
             {% set notify_service = states('input_text.notify_service_server') %}
+          {% elif states.input_text.notify_service.state is defined %}
+            {% set notify_service = states('input_text.notify_service') %}
           {% else %}
             {% set notify_service = 'notify' %}
           {% endif %}
@@ -78,6 +84,8 @@ automation:
       - service: >-
           {% if states.input_text.notify_service_server.state is defined %}
             {% set notify_service = states('input_text.notify_service_server') %}
+          {% elif states.input_text.notify_service.state is defined %}
+            {% set notify_service = states('input_text.notify_service') %}
           {% else %}
             {% set notify_service = 'notify' %}
           {% endif %}
@@ -100,6 +108,8 @@ automation:
       - service: >-
           {% if states.input_text.notify_service_server.state is defined %}
             {% set notify_service = states('input_text.notify_service_server') %}
+          {% elif states.input_text.notify_service.state is defined %}
+            {% set notify_service = states('input_text.notify_service') %}
           {% else %}
             {% set notify_service = 'notify' %}
           {% endif %}
@@ -110,6 +120,8 @@ automation:
       - service: >-
           {% if states.input_text.notify_service_server.state is defined %}
             {% set notify_service = states('input_text.notify_service_server') %}
+          {% elif states.input_text.notify_service.state is defined %}
+            {% set notify_service = states('input_text.notify_service') %}
           {% else %}
             {% set notify_service = 'notify' %}
           {% endif %}

--- a/packages/hacs.yaml
+++ b/packages/hacs.yaml
@@ -71,6 +71,8 @@ automation:
               - service: >-
                   {% if states.input_text.notify_service_updates.state is defined %}
                     {% set notify_service = states('input_text.notify_service_updates') %}
+                  {% elif states.input_text.notify_service.state is defined %}
+                    {% set notify_service = states('input_text.notify_service') %}
                   {% else %}
                     {% set notify_service = 'notify' %}
                   {% endif %}
@@ -89,6 +91,8 @@ automation:
                   hours: >-
                     {% if states.input_number.delay_notify_updates.state is defined %}
                       {% set hours = states('input_number.delay_notify_updates') | int %}
+                    {% elif states.input_text.notify_service.state is defined %}
+                      {% set notify_service = states('input_text.notify_service') %}
                     {% else %}
                       {% set hours = 120 %}
                     {% endif %}
@@ -99,6 +103,8 @@ automation:
               - service: >-
                   {% if states.input_text.notify_service_updates.state is defined %}
                     {% set notify_service = states('input_text.notify_service_updates') %}
+                  {% elif states.input_text.notify_service.state is defined %}
+                    {% set notify_service = states('input_text.notify_service') %}
                   {% else %}
                     {% set notify_service = 'notify' %}
                   {% endif %}
@@ -119,6 +125,8 @@ automation:
               - service: >-
                   {% if states.input_text.notify_service_updates.state is defined %}
                     {% set notify_service = states('input_text.notify_service_updates') %}
+                  {% elif states.input_text.notify_service.state is defined %}
+                    {% set notify_service = states('input_text.notify_service') %}
                   {% else %}
                     {% set notify_service = 'notify' %}
                   {% endif %}

--- a/packages/low_battery.yaml
+++ b/packages/low_battery.yaml
@@ -1,4 +1,4 @@
-# Version: 2023.10.1
+# Version: 2024.04.1
 # Low Batteries Package
 #
 # Count and list of entities device class battery with the value under 20

--- a/packages/low_battery.yaml
+++ b/packages/low_battery.yaml
@@ -129,6 +129,8 @@ automation:
               - service: >-
                   {% if states.input_text.notify_service_batteries.state is defined %}
                     {% set notify_service = states('input_text.notify_service_batteries') %}
+                  {% elif states.input_text.notify_service.state is defined %}
+                    {% set notify_service = states('input_text.notify_service') %}
                   {% else %}
                     {% set notify_service = 'notify' %}
                   {% endif %}
@@ -157,6 +159,8 @@ automation:
               - service: >-
                   {% if states.input_text.notify_service_batteries.state is defined %}
                     {% set notify_service = states('input_text.notify_service_batteries') %}
+                  {% elif states.input_text.notify_service.state is defined %}
+                    {% set notify_service = states('input_text.notify_service') %}
                   {% else %}
                     {% set notify_service = 'notify' %}
                   {% endif %}
@@ -184,6 +188,8 @@ automation:
               - service: >-
                   {% if states.input_text.notify_service_batteries.state is defined %}
                     {% set notify_service = states('input_text.notify_service_batteries') %}
+                  {% elif states.input_text.notify_service.state is defined %}
+                    {% set notify_service = states('input_text.notify_service') %}
                   {% else %}
                     {% set notify_service = 'notify' %}
                   {% endif %}

--- a/packages/low_battery.yaml
+++ b/packages/low_battery.yaml
@@ -46,11 +46,7 @@ template:
       - name: "|| Low Batteries"
         icon: "hass:battery-alert-variant-outline"
         state: >
-              {% if states.input_select.ignored_batteries.state is defined %}
-                {% set ignored = state_attr('input_select.ignored_batteries','options') %}
-              {% else %}
-                {% set ignored = [] %}
-              {% endif %}
+              {% set ignored = label_entities('ignore') %}
                     
               {% if states.input_number.battery_level_threshold.state is defined %}
                 {% set threshold = states('input_number.battery_level_threshold') | int %}
@@ -71,11 +67,7 @@ template:
               {{ result.sensors|count }}
         attributes:
             names: >
-              {% if states.input_select.ignored_batteries.state is defined %}
-                {% set ignored = state_attr('input_select.ignored_batteries','options') %}
-              {% else %}
-                {% set ignored = [] %}
-              {% endif %}
+              {% set ignored = label_entities('ignore') %}
                     
               {% if states.input_number.battery_level_threshold.state is defined %}
                 {% set threshold = states('input_number.battery_level_threshold') | int %}

--- a/packages/problems.yaml
+++ b/packages/problems.yaml
@@ -1,4 +1,4 @@
-# Version: 2023.10.2
+# Version: 2024.04.1
 # Problems found Package
 #
 # List all available problems entities with device class problem
@@ -46,11 +46,7 @@ template:
       - name: "|| Problems Detected"
         icon: "hass:alert-outline"
         state: >
-              {% if states.input_select.ignored_problems.state is defined %}
-                {% set ignored = state_attr('input_select.ignored_problems','options') %}
-              {% else %}
-                {% set ignored = [] %}
-              {% endif %}
+              {% set ignored = label_entities('ignore') %}
                     
               {{ states.binary_sensor
                 |selectattr('attributes.device_class','defined')
@@ -61,11 +57,7 @@ template:
               }}
         attributes:
             names: >
-              {% if states.input_select.ignored_problems.state is defined %}
-                {% set ignored = state_attr('input_select.ignored_problems','options') %}
-              {% else %}
-                {% set ignored = [] %}
-              {% endif %}
+              {% set ignored = label_entities('ignore') %}
                     
               {{ states.binary_sensor
                 |selectattr('attributes.device_class','defined')

--- a/packages/problems.yaml
+++ b/packages/problems.yaml
@@ -127,6 +127,8 @@ automation:
               - service: >
                   {% if states.input_text.notify_service_problems.state is defined %}
                     {% set notify_service = states('input_text.notify_service_problems') %}
+                  {% elif states.input_text.notify_service.state is defined %}
+                    {% set notify_service = states('input_text.notify_service') %}
                   {% else %}
                     {% set notify_service = 'notify' %}
                   {% endif %}
@@ -161,6 +163,8 @@ automation:
               - service: >-
                   {% if states.input_text.notify_service_problems.state is defined %}
                     {% set notify_service = states('input_text.notify_service_problems') %}
+                  {% elif states.input_text.notify_service.state is defined %}
+                    {% set notify_service = states('input_text.notify_service') %}
                   {% else %}
                     {% set notify_service = 'notify' %}
                   {% endif %}
@@ -181,6 +185,8 @@ automation:
               - service: >-
                   {% if states.input_text.notify_service_problems.state is defined %}
                     {% set notify_service = states('input_text.notify_service_problems') %}
+                  {% elif states.input_text.notify_service.state is defined %}
+                    {% set notify_service = states('input_text.notify_service') %}
                   {% else %}
                     {% set notify_service = 'notify' %}
                   {% endif %}

--- a/packages/raspberrypi.yaml
+++ b/packages/raspberrypi.yaml
@@ -37,6 +37,8 @@ automation:
       - service: >-
           {% if states.input_text.notify_service_server.state is defined %}
             {% set notify_service = states('input_text.notify_service_server') %}
+          {% elif states.input_text.notify_service.state is defined %}
+            {% set notify_service = states('input_text.notify_service') %}
           {% else %}
             {% set notify_service = 'notify' %}
           {% endif %}
@@ -47,6 +49,8 @@ automation:
       - service: >-
           {% if states.input_text.notify_service_server.state is defined %}
             {% set notify_service = states('input_text.notify_service_server') %}
+          {% elif states.input_text.notify_service.state is defined %}
+            {% set notify_service = states('input_text.notify_service') %}
           {% else %}
             {% set notify_service = 'notify' %}
           {% endif %}

--- a/packages/server.yaml
+++ b/packages/server.yaml
@@ -108,6 +108,8 @@ automation:
     - service: >-
         {% if states.input_text.notify_service_server.state is defined %}
           {% set notify_service = states('input_text.notify_service_server') %}
+        {% elif states.input_text.notify_service.state is defined %}
+          {% set notify_service = states('input_text.notify_service') %}
         {% else %}
           {% set notify_service = 'notify' %}
         {% endif %}
@@ -132,6 +134,8 @@ automation:
     - service: >-
         {% if states.input_text.notify_service_server.state is defined %}
           {% set notify_service = states('input_text.notify_service_server') %}
+        {% elif states.input_text.notify_service.state is defined %}
+          {% set notify_service = states('input_text.notify_service') %}
         {% else %}
           {% set notify_service = 'notify' %}
         {% endif %}
@@ -221,6 +225,8 @@ automation:
       - service: >-
           {% if states.input_text.notify_service_server.state is defined %}
             {% set notify_service = states('input_text.notify_service_server') %}
+          {% elif states.input_text.notify_service.state is defined %}
+            {% set notify_service = states('input_text.notify_service') %}
           {% else %}
             {% set notify_service = 'notify' %}
           {% endif %}
@@ -232,6 +238,8 @@ automation:
       - service: >-
           {% if states.input_text.notify_service_server.state is defined %}
             {% set notify_service = states('input_text.notify_service_server') %}
+          {% elif states.input_text.notify_service.state is defined %}
+            {% set notify_service = states('input_text.notify_service') %}
           {% else %}
             {% set notify_service = 'notify' %}
           {% endif %}
@@ -258,6 +266,8 @@ automation:
       - service: >-
           {% if states.input_text.notify_service_server.state is defined %}
             {% set notify_service = states('input_text.notify_service_server') %}
+          {% elif states.input_text.notify_service.state is defined %}
+            {% set notify_service = states('input_text.notify_service') %}
           {% else %}
             {% set notify_service = 'notify' %}
           {% endif %}
@@ -269,6 +279,8 @@ automation:
       - service: >-
           {% if states.input_text.notify_service_server.state is defined %}
             {% set notify_service = states('input_text.notify_service_server') %}
+          {% elif states.input_text.notify_service.state is defined %}
+            {% set notify_service = states('input_text.notify_service') %}
           {% else %}
             {% set notify_service = 'notify' %}
           {% endif %}
@@ -294,6 +306,8 @@ automation:
       - service: >-
           {% if states.input_text.notify_service_server.state is defined %}
             {% set notify_service = states('input_text.notify_service_server') %}
+          {% elif states.input_text.notify_service.state is defined %}
+            {% set notify_service = states('input_text.notify_service') %}
           {% else %}
             {% set notify_service = 'notify' %}
           {% endif %}
@@ -304,6 +318,8 @@ automation:
       - service: >-
           {% if states.input_text.notify_service_server.state is defined %}
             {% set notify_service = states('input_text.notify_service_server') %}
+          {% elif states.input_text.notify_service.state is defined %}
+            {% set notify_service = states('input_text.notify_service') %}
           {% else %}
             {% set notify_service = 'notify' %}
           {% endif %}
@@ -391,6 +407,8 @@ automation:
               - service: >-
                   {% if states.input_text.notify_service_server.state is defined %}
                     {% set notify_service = states('input_text.notify_service_server') %}
+                  {% elif states.input_text.notify_service.state is defined %}
+                    {% set notify_service = states('input_text.notify_service') %}
                   {% else %}
                     {% set notify_service = 'notify' %}
                   {% endif %}
@@ -414,6 +432,8 @@ automation:
               - service: >-
                   {% if states.input_text.notify_service_server.state is defined %}
                     {% set notify_service = states('input_text.notify_service_server') %}
+                  {% elif states.input_text.notify_service.state is defined %}
+                    {% set notify_service = states('input_text.notify_service') %}
                   {% else %}
                     {% set notify_service = 'notify' %}
                   {% endif %}

--- a/packages/unavailable_entities.yaml
+++ b/packages/unavailable_entities.yaml
@@ -158,6 +158,8 @@ automation:
               - service: >-
                   {% if states.input_text.notify_service_unavailable.state is defined %}
                     {% set notify_service = states('input_text.notify_service_unavailable') %}
+                  {% elif states.input_text.notify_service.state is defined %}
+                    {% set notify_service = states('input_text.notify_service') %}
                   {% else %}
                     {% set notify_service = 'notify' %}
                   {% endif %}
@@ -192,6 +194,8 @@ automation:
               - service: >-
                   {% if states.input_text.notify_service_unavailable.state is defined %}
                     {% set notify_service = states('input_text.notify_service_unavailable') %}
+                  {% elif states.input_text.notify_service.state is defined %}
+                    {% set notify_service = states('input_text.notify_service') %}
                   {% else %}
                     {% set notify_service = 'notify' %}
                   {% endif %}
@@ -212,6 +216,8 @@ automation:
               - service: >-
                   {% if states.input_text.notify_service_unavailable.state is defined %}
                     {% set notify_service = states('input_text.notify_service_unavailable') %}
+                  {% elif states.input_text.notify_service.state is defined %}
+                    {% set notify_service = states('input_text.notify_service') %}
                   {% else %}
                     {% set notify_service = 'notify' %}
                   {% endif %}
@@ -270,6 +276,8 @@ automation:
               - service: >-
                   {% if states.input_text.notify_service_unavailable.state is defined %}
                     {% set notify_service = states('input_text.notify_service_unavailable') %}
+                  {% elif states.input_text.notify_service.state is defined %}
+                    {% set notify_service = states('input_text.notify_service') %}
                   {% else %}
                     {% set notify_service = 'notify' %}
                   {% endif %}
@@ -304,6 +312,8 @@ automation:
               - service: >-
                   {% if states.input_text.notify_service_unavailable.state is defined %}
                     {% set notify_service = states('input_text.notify_service_unavailable') %}
+                  {% elif states.input_text.notify_service.state is defined %}
+                    {% set notify_service = states('input_text.notify_service') %}
                   {% else %}
                     {% set notify_service = 'notify' %}
                   {% endif %}
@@ -324,6 +334,8 @@ automation:
               - service: >-
                   {% if states.input_text.notify_service_unavailable.state is defined %}
                     {% set notify_service = states('input_text.notify_service_unavailable') %}
+                  {% elif states.input_text.notify_service.state is defined %}
+                    {% set notify_service = states('input_text.notify_service') %}
                   {% else %}
                     {% set notify_service = 'notify' %}
                   {% endif %}

--- a/packages/unavailable_entities.yaml
+++ b/packages/unavailable_entities.yaml
@@ -1,4 +1,4 @@
-# Version 2023.12.1
+# Version 2024.04.1
 # Package - Unavailable Entities
 # Count and list of devices and sensors with a state of unavailable
 #
@@ -43,11 +43,7 @@ template:
       - name: "|| Unavailable Entities"
         icon: "hass:shape"
         state: >
-              {% if states.input_select.ignored_unavailable.state is defined %}
-                {% set ignored = state_attr('input_select.ignored_unavailable','options') %}
-              {% else %}
-                {% set ignored = [] %}
-              {% endif %}
+              {% set ignored = label_entities('ignore') %}
                     
               {{ states
                 |selectattr('domain','in',['switch','light','cover','climate','camera','lock','remote'])
@@ -57,11 +53,7 @@ template:
               }}
         attributes:
             names: >
-              {% if states.input_select.ignored_unavailable.state is defined %}
-                {% set ignored = state_attr('input_select.ignored_unavailable','options') %}
-              {% else %}
-                {% set ignored = [] %}
-              {% endif %}
+              {% set ignored = label_entities('ignore') %}
                     
               {{ states
                 |selectattr('domain','in',['switch','light','cover','climate','camera','lock','remote'])
@@ -77,11 +69,7 @@ template:
       - name: "|| Unavailable Sensors"
         icon: "hass:shape"
         state: >
-              {% if states.input_select.ignored_unavailable.state is defined %}
-                {% set ignored = state_attr('input_select.ignored_unavailable','options') %}
-              {% else %}
-                {% set ignored = [] %}
-              {% endif %}
+              {% set ignored = label_entities('ignore') %}
                     
               {{ states
                 |selectattr('domain','in',['sensor','binary_sensor'])
@@ -93,11 +81,7 @@ template:
               }}
         attributes:
             names: >
-              {% if states.input_select.ignored_unavailable.state is defined %}
-                {% set ignored = state_attr('input_select.ignored_unavailable','options') %}
-              {% else %}
-                {% set ignored = [] %}
-              {% endif %}
+              {% set ignored = label_entities('ignore') %}
                   
               {{ states
                 |selectattr('domain','in',['sensor','binary_sensor'])

--- a/packages/updates_available.yaml
+++ b/packages/updates_available.yaml
@@ -171,6 +171,8 @@ automation:
               - service: >-
                   {% if states.input_text.notify_service_updates.state is defined %}
                       {% set notify_service = states('input_text.notify_service_updates') %}
+                    {% elif states.input_text.notify_service.state is defined %}
+                      {% set notify_service = states('input_text.notify_service') %}
                     {% else %}
                       {% set notify_service = 'notify' %}
                   {% endif %}
@@ -196,6 +198,8 @@ automation:
               - service: >-
                   {% if states.input_text.notify_service_updates.state is defined %}
                       {% set notify_service = states('input_text.notify_service_updates') %}
+                    {% elif states.input_text.notify_service.state is defined %}
+                      {% set notify_service = states('input_text.notify_service') %}
                     {% else %}
                       {% set notify_service = 'notify' %}
                   {% endif %}
@@ -226,6 +230,8 @@ automation:
               - service: >-
                   {% if states.input_text.notify_service_updates.state is defined %}
                       {% set notify_service = states('input_text.notify_service_updates') %}
+                    {% elif states.input_text.notify_service.state is defined %}
+                      {% set notify_service = states('input_text.notify_service') %}
                     {% else %}
                       {% set notify_service = 'notify' %}
                   {% endif %}
@@ -273,6 +279,8 @@ automation:
               - service: >-
                   {% if states.input_text.notify_service_updates.state is defined %}
                       {% set notify_service = states('input_text.notify_service_updates') %}
+                    {% elif states.input_text.notify_service.state is defined %}
+                      {% set notify_service = states('input_text.notify_service') %}
                     {% else %}
                       {% set notify_service = 'notify' %}
                   {% endif %}
@@ -295,6 +303,8 @@ automation:
               - service: >-
                   {% if states.input_text.notify_service_updates.state is defined %}
                       {% set notify_service = states('input_text.notify_service_updates') %}
+                    {% elif states.input_text.notify_service.state is defined %}
+                      {% set notify_service = states('input_text.notify_service') %}
                     {% else %}
                       {% set notify_service = 'notify' %}
                   {% endif %}
@@ -320,6 +330,8 @@ automation:
               - service: >-
                   {% if states.input_text.notify_service_updates.state is defined %}
                       {% set notify_service = states('input_text.notify_service_updates') %}
+                    {% elif states.input_text.notify_service.state is defined %}
+                      {% set notify_service = states('input_text.notify_service') %}
                     {% else %}
                       {% set notify_service = 'notify' %}
                   {% endif %}

--- a/packages/updates_available.yaml
+++ b/packages/updates_available.yaml
@@ -1,4 +1,4 @@
-# Version: 2023.12.1
+# Version: 2024.04.1
 # Updates Available Package
 #
 # Auto update all addons, firmware, core, os.
@@ -50,11 +50,7 @@ template:
       - name: "|| Updates Available"
         icon: "hass:update"
         state: >
-              {% if states.input_select.ignored_updates.state is defined %}
-                {% set ignored = state_attr('input_select.ignored_updates','options') %}
-              {% else %}
-                {% set ignored = [] %}
-              {% endif %}
+              {% set ignored = label_entities('ignore') %}
                     
               {% set result = namespace(updates=[]) %}
               {% if states.input_number.delay_notify_updates.state is defined %}
@@ -90,11 +86,7 @@ template:
               {{ result.updates|count }}
         attributes:
             names: >
-              {% if states.input_select.ignored_updates.state is defined %}
-                {% set ignored = state_attr('input_select.ignored_updates','options') %}
-              {% else %}
-                {% set ignored = [] %}
-              {% endif %}
+              {% set ignored = label_entities('ignore') %}
                     
               {% set result = namespace(updates=[]) %}
               {% if states.input_number.delay_notify_updates.state is defined %}
@@ -356,11 +348,7 @@ automation:
           - conditions:
               - condition: template
                 value_template: >
-                  {% if states.input_select.ignored_updates.state is defined %}
-                    {% set ignored = state_attr('input_select.ignored_updates','options') %}
-                  {% else %}
-                    {% set ignored = [] %}
-                  {% endif %}
+                  {% set ignored = label_entities('ignore') %}
                     
                   {% set result = namespace(updates=[]) %}
                   {% if states.input_number.delay_auto_update.state is defined %}
@@ -390,11 +378,7 @@ automation:
               - service: update.install
                 target:
                   entity_id: >
-                    {% if states.input_select.ignored_updates.state is defined %}
-                      {% set ignored = state_attr('input_select.ignored_updates','options') %}
-                    {% else %}
-                      {% set ignored = [] %}
-                    {% endif %}
+                    {% set ignored = label_entities('ignore') %}
                       
                     {% set result = namespace(updates=[]) %}
                     {% if states.input_number.delay_auto_update.state is defined %}
@@ -427,11 +411,7 @@ automation:
                 conditions:
                   - condition: template
                     value_template: >
-                      {% if states.input_select.ignored_updates.state is defined %}
-                        {% set ignored = state_attr('input_select.ignored_updates','options') %}
-                      {% else %}
-                        {% set ignored = [] %}
-                      {% endif %}
+                      {% set ignored = label_entities('ignore') %}
 
                       {% set result = namespace(updates=[]) %}
                       {% if states.input_number.delay_auto_update.state is defined %}
@@ -454,11 +434,7 @@ automation:
 
                   - condition: template
                     value_template: >
-                      {% if states.input_select.ignored_updates.state is defined %}
-                        {% set ignored = state_attr('input_select.ignored_updates','options') %}
-                      {% else %}
-                        {% set ignored = [] %}
-                      {% endif %}
+                      {% set ignored = label_entities('ignore') %}
                       
                       {% set result = namespace(updates=[]) %}
                       {% for state in states.update 
@@ -491,11 +467,7 @@ automation:
               - if:
                   - condition: template
                     value_template: >
-                          {% if states.input_select.ignored_updates.state is defined %}
-                            {% set ignored = state_attr('input_select.ignored_updates','options') %}
-                          {% else %}
-                            {% set ignored = [] %}
-                          {% endif %}
+                          {% set ignored = label_entities('ignore') %}
                           
                           {% set result = namespace(updates=[]) %}
                           {% for state in states.update 
@@ -513,11 +485,7 @@ automation:
                     data: {}
                     target:
                       entity_id: >
-                          {% if states.input_select.ignored_updates.state is defined %}
-                            {% set ignored = state_attr('input_select.ignored_updates','options') %}
-                          {% else %}
-                            {% set ignored = [] %}
-                          {% endif %}
+                          {% set ignored = label_entities('ignore') %}
               
                           {% set result = namespace(updates=[]) %}
                           {% for state in states.update 
@@ -535,11 +503,7 @@ automation:
           - conditions:
               - condition: template
                 value_template: >
-                  {% if states.input_select.ignored_updates.state is defined %}
-                    {% set ignored = state_attr('input_select.ignored_updates','options') %}
-                  {% else %}
-                    {% set ignored = [] %}
-                  {% endif %}
+                  {% set ignored = label_entities('ignore') %}
                   
                   {% set result = namespace(updates=[]) %}
                     {% if states.input_number.delay_auto_update.state is defined %}
@@ -563,11 +527,7 @@ automation:
               - service: update.install
                 target:
                   entity_id: >
-                    {% if states.input_select.ignored_updates.state is defined %}
-                      {% set ignored = state_attr('input_select.ignored_updates','options') %}
-                    {% else %}
-                      {% set ignored = [] %}
-                    {% endif %}
+                    {% set ignored = label_entities('ignore') %}
                     
                     {% set result = namespace(updates=[]) %}
                       {% if states.input_number.delay_auto_update.state is defined %}
@@ -592,11 +552,7 @@ automation:
           - conditions:
               - condition: template
                 value_template: >
-                    {% if states.input_select.ignored_updates.state is defined %}
-                      {% set ignored = state_attr('input_select.ignored_updates','options') %}
-                    {% else %}
-                      {% set ignored = [] %}
-                    {% endif %}
+                    {% set ignored = label_entities('ignore') %}
 
                     {% set result = namespace(updates=[]) %}
                     {% if states.input_number.delay_auto_update.state is defined %}
@@ -627,11 +583,7 @@ automation:
           - conditions:
               - condition: template
                 value_template: >
-                    {% if states.input_select.ignored_updates.state is defined %}
-                      {% set ignored = state_attr('input_select.ignored_updates','options') %}
-                    {% else %}
-                      {% set ignored = [] %}
-                    {% endif %}
+                    {% set ignored = label_entities('ignore') %}
 
                     {% set result = namespace(updates=[]) %}
                     {% if states.input_number.delay_auto_update.state is defined %}

--- a/packages/windows_and_doors.yaml
+++ b/packages/windows_and_doors.yaml
@@ -1,4 +1,4 @@
-# Version: 2023.10.2
+# Version: 2024.04.1
 # Open Windows Package
 # This package create a sensor with number of open windows
 #
@@ -35,11 +35,8 @@ template:
       - name: "Open Windows"
         icon: "hass:window-open"
         state: >
-              {% if states.input_select.ignored_windows.state is defined %}
-                {% set ignored = state_attr('input_select.ignored_windows','options') %}
-              {% else %}
-                {% set ignored = [] %}
-              {% endif %}
+              {% set ignored = label_entities('ignore') %}
+              
               {{ states.binary_sensor
                 |selectattr('attributes.device_class','defined')
                 |selectattr('attributes.device_class','eq','window')
@@ -49,11 +46,7 @@ template:
               }}
         attributes:
             names: >
-              {% if states.input_select.ignored_windows.state is defined %}
-                {% set ignored = state_attr('input_select.ignored_windows','options') %}
-              {% else %}
-                {% set ignored = [] %}
-              {% endif %}
+              {% set ignored = label_entities('ignore') %}
 
               {{ states.binary_sensor
                 |selectattr('attributes.device_class','defined')
@@ -66,11 +59,7 @@ template:
       - name: "Open Doors"
         icon: "hass:door-open"
         state: >
-              {% if states.input_select.ignored_doors.state is defined %}
-                {% set ignored = state_attr('input_select.ignored_doors','options') %}
-              {% else %}
-                {% set ignored = [] %}
-              {% endif %}
+              {% set ignored = label_entities('ignore') %}
               
               {{ states.binary_sensor
                 |selectattr('attributes.device_class','defined')
@@ -81,11 +70,7 @@ template:
               }}
         attributes:
             names: >
-              {% if states.input_select.ignored_doors.state is defined %}
-                {% set ignored = state_attr('input_select.ignored_doors','options') %}
-              {% else %}
-                {% set ignored = [] %}
-              {% endif %}
+              {% set ignored = label_entities('ignore') %}
               
               {{ states.binary_sensor
                 |selectattr('attributes.device_class','defined')


### PR DESCRIPTION
Use the new label function for ignoring entities in packages. Use label Ignore for all entities that you want to exclude from packages.

Added option to use only one helper for all notifications called "|| Notify Service"
If specific notify service is added that will be used instead the general one.