### PR TITLE
Avoid warnings in logs on reload packages

### DIFF
--- a/packages/hacs.yaml
+++ b/packages/hacs.yaml
@@ -31,11 +31,6 @@ input_boolean:
     name: "𐃏 Updates Available Alert HACS"
     icon: "hass:alert-circle"
 
-group:
-  turn_off_automations:
-    entities:
-      - automation.updates_available_hacs
-
 automation:
   # Notify when updates are available
   - id: "updates_available_hacs"

--- a/packages/low_battery.yaml
+++ b/packages/low_battery.yaml
@@ -30,11 +30,6 @@ script:
             {% set name = 'low_battery.yaml' %}
             {{ url + account + path + name }}
 
-group:
-  turn_off_automations:
-    entities:
-      - automation.low_batteries
-
 template:
   - trigger:
       - platform: time_pattern

--- a/packages/low_battery.yaml
+++ b/packages/low_battery.yaml
@@ -1,4 +1,4 @@
-# Version: 2024.07.3
+# Version: 2024.07.4
 # Low Batteries Package
 #
 # Count and list of entities device class battery with the value under 20
@@ -123,6 +123,17 @@ automation:
         entity_id: binary_sensor.batteries_ok
       - platform: homeassistant
         event: start
+    condition:
+      - condition: not
+        conditions:
+          - condition: state
+            entity_id: sensor.low_batteries
+            state: unknown
+      - condition: not
+        conditions:
+          - condition: state
+            entity_id: binary_sensor.batteries_ok
+            state: unknown
     action:
       - choose:
           - conditions:

--- a/packages/low_battery.yaml
+++ b/packages/low_battery.yaml
@@ -1,4 +1,4 @@
-# Version: 2024.07.4
+# Version: 2024.07.5
 # Low Batteries Package
 #
 # Count and list of entities device class battery with the value under 20
@@ -136,11 +136,6 @@ automation:
             state: unknown
     action:
       - choose:
-          - conditions:
-              - condition: state
-                entity_id: sensor.low_batteries
-                state: unknown
-            sequence: []
           - conditions:
               - condition: numeric_state
                 entity_id: sensor.low_batteries

--- a/packages/low_battery.yaml
+++ b/packages/low_battery.yaml
@@ -1,4 +1,4 @@
-# Version: 2024.07.5
+# Version: 2024.07.6
 # Low Batteries Package
 #
 # Count and list of entities device class battery with the value under 20
@@ -124,16 +124,10 @@ automation:
       - platform: homeassistant
         event: start
     condition:
-      - condition: not
-        conditions:
-          - condition: state
-            entity_id: sensor.low_batteries
-            state: unknown
-      - condition: not
-        conditions:
-          - condition: state
-            entity_id: binary_sensor.batteries_ok
-            state: unknown
+      - condition: template
+        value_template: "{{ states.sensor.low_batteries.state is defined }}"
+      - condition: template
+        value_template: "{{ states.binary_sensor.batteries_ok.state is defined }}"
     action:
       - choose:
           - conditions:

--- a/packages/problems.yaml
+++ b/packages/problems.yaml
@@ -32,11 +32,6 @@ script:
             {% set name = 'problems.yaml' %}
             {{ url + account + path + name }}
             
-            
-group:
-  turn_off_automations:
-    entities:
-      - automation.problems_detected
 
 template:
   - trigger:

--- a/packages/problems.yaml
+++ b/packages/problems.yaml
@@ -1,4 +1,4 @@
-# Version: 2024.06.2
+# Version: 2024.07.1
 # Problems found Package
 #
 # List all available problems entities with device class problem
@@ -89,13 +89,10 @@ automation:
       - condition: state
         entity_id: input_boolean.maintenance_mode
         state: "off"
+      - condition: template
+        value_template: "{{ states.sensor.problems_detected.state is defined }}"
     action:
       - choose:
-          - conditions:
-              - condition: state
-                entity_id: sensor.problems_detected
-                state: unknown
-            sequence: []
           - conditions:
               - condition: numeric_state
                 entity_id: sensor.problems_detected

--- a/packages/server.yaml
+++ b/packages/server.yaml
@@ -1,4 +1,4 @@
-# Version: 2024.7.2
+# Version: 2024.7.3
 # Package Server
 # This package includes default integrations, automations 
 # and sersors for server activity.
@@ -343,7 +343,9 @@ automation:
       - platform: state
         entity_id:
           - sensor.updates_in_progress
-    condition: []
+    condition:
+      - condition: template
+        value_template: "{{ states.sensor.updates_in_progress.state is defined }}"
     action:
       - choose:
           - conditions:

--- a/packages/server.yaml
+++ b/packages/server.yaml
@@ -198,7 +198,7 @@ automation:
     condition: []
     action:
       - delay:
-          seconds: 10
+          seconds: 5
       - service: homeassistant.reload_all
     mode: restart
 

--- a/packages/server.yaml
+++ b/packages/server.yaml
@@ -197,6 +197,8 @@ automation:
         to: 'off'
     condition: []
     action:
+      - delay:
+          seconds: 10
       - service: homeassistant.reload_all
     mode: restart
 

--- a/packages/server.yaml
+++ b/packages/server.yaml
@@ -68,11 +68,6 @@ logbook:
       - sensor.*_load_*
       - sensor.load_*
 
-group:
-  turn_off_automations:
-    name: "𐃏 Turn OFF Automations"
-    entities: []
-
 automation:
     # Update Packages on server STOP
   - id: 'update_on_server_stop'
@@ -91,8 +86,6 @@ automation:
     - service: script.turn_on
       target:
         entity_id: script.update_packages
-    - delay:
-        seconds: 5
     mode: single
 
     # Notify on server start using defined service
@@ -146,7 +139,7 @@ automation:
       data:
         message: ⏹️ Serverul s-a oprit!
     - delay:
-        seconds: 5
+        seconds: 10
     mode: single
 
     # Ping healthchecks.io every minute
@@ -198,7 +191,7 @@ automation:
     condition: []
     action:
       - delay:
-          seconds: 5
+          seconds: 10
       - service: homeassistant.reload_all
     mode: restart
 

--- a/packages/server.yaml
+++ b/packages/server.yaml
@@ -1,4 +1,4 @@
-# Version: 2024.7.1
+# Version: 2024.7.2
 # Package Server
 # This package includes default integrations, automations 
 # and sersors for server activity.
@@ -92,10 +92,7 @@ automation:
       target:
         entity_id: script.update_packages
     - delay:
-        hours: 0
-        minutes: 0
         seconds: 5
-        milliseconds: 0
     mode: single
 
     # Notify on server start using defined service
@@ -148,6 +145,8 @@ automation:
         {{ "notify." + notify_service }}
       data:
         message: ⏹️ Serverul s-a oprit!
+    - delay:
+        seconds: 5
     mode: single
 
     # Ping healthchecks.io every minute
@@ -198,20 +197,7 @@ automation:
         to: 'off'
     condition: []
     action:
-      - service: automation.turn_off
-        target:
-          entity_id: group.turn_off_automations
-      - service: input_boolean.reload
-      - service: input_number.reload
-      - service: input_text.reload
-      - service: template.reload
-      - service: group.reload
-      - service: script.reload
-      - service: homeassistant.reload_core_config
-      - service: automation.turn_on
-        target:
-          entity_id: group.turn_off_automations
-      - service: automation.reload
+      - service: homeassistant.reload_all
     mode: restart
 
     # Notify when CPU load 15m is above 4 and when goes back below 3
@@ -235,7 +221,7 @@ automation:
           {% else %}
             {% set notify_service = 'notify' %}
           {% endif %}
-           
+          
           {{ "notify." + notify_service }}
         data:
           message: "🟡 CPU Load (15m) = {{ states('sensor.load_15m') }}"
@@ -248,7 +234,7 @@ automation:
           {% else %}
             {% set notify_service = 'notify' %}
           {% endif %}
-           
+          
           {{ "notify." + notify_service }}
         data:
           message: "🟢 CPU Load (15m) = {{ states('sensor.load_15m') }}"
@@ -276,7 +262,7 @@ automation:
           {% else %}
             {% set notify_service = 'notify' %}
           {% endif %}
-           
+          
           {{ "notify." + notify_service }}
         data:
           message: "🟡 RAM = {{ states('sensor.memory_use_percent') }}%"
@@ -384,7 +370,7 @@ automation:
                 target:
                   entity_id: input_boolean.maintenance_mode
     mode: single
- 
+
   - id: maintenance_notifications
     alias: "𐃏 Maintenance Notifications"
     description: ""

--- a/packages/unavailable_entities.yaml
+++ b/packages/unavailable_entities.yaml
@@ -1,4 +1,4 @@
-# Version 2024.07.1
+# Version 2024.07.2
 # Package - Unavailable Entities
 # Count and list of devices and sensors with a state of unavailable
 #
@@ -119,13 +119,10 @@ automation:
       - condition: state
         entity_id: input_boolean.maintenance_mode
         state: "off"
+      - condition: template
+        value_template: "{{ states.sensor.unavailable_entities.state is defined }}"
     action:
       - choose:
-          - conditions:
-              - condition: state
-                entity_id: sensor.unavailable_entities
-                state: unknown
-            sequence: []
           - conditions:
               - condition: numeric_state
                 entity_id: sensor.unavailable_entities
@@ -237,13 +234,10 @@ automation:
       - condition: state
         entity_id: input_boolean.maintenance_mode
         state: "off"
+      - condition: template
+        value_template: "{{ states.sensor.unavailable_sensors.state is defined }}"
     action:
       - choose:
-          - conditions:
-              - condition: state
-                entity_id: sensor.unavailable_sensors
-                state: unknown
-            sequence: []
           - conditions:
               - condition: numeric_state
                 entity_id: sensor.unavailable_sensors

--- a/packages/unavailable_entities.yaml
+++ b/packages/unavailable_entities.yaml
@@ -29,12 +29,6 @@ script:
             {% set name = 'unavailable_entities.yaml' %}
             {{ url + account + path + name }}
 
-group:
-  turn_off_automations:
-    entities:
-      - automation.unavailable_entities
-      - automation.unavailable_sensors
-
 template:
   - trigger:
       - platform: time_pattern

--- a/packages/updates_available.yaml
+++ b/packages/updates_available.yaml
@@ -1,4 +1,4 @@
-# Version: 2024.07.3
+# Version: 2024.07.4
 # Updates Available Package
 #
 # Auto update all addons, firmware, core, os.
@@ -259,8 +259,6 @@ automation:
       - condition: template
         value_template: "{{ states.sensor.updates_in_progress.state is defined }}"
     action:
-      - delay:
-          seconds: 10
       - choose:
           - conditions:
               - condition: numeric_state
@@ -268,6 +266,8 @@ automation:
                 above: "0"
                 below: "2"
             sequence:
+              - delay:
+                  seconds: 10
               - service: >-
                   {% if states.input_text.notify_service_updates.state is defined %}
                       {% set notify_service = states('input_text.notify_service_updates') %}
@@ -292,6 +292,8 @@ automation:
                 entity_id: sensor.updates_in_progress
                 above: "1"
             sequence:
+              - delay:
+                  seconds: 10
               - service: >-
                   {% if states.input_text.notify_service_updates.state is defined %}
                       {% set notify_service = states('input_text.notify_service_updates') %}
@@ -319,6 +321,8 @@ automation:
                 entity_id: input_boolean.update_in_progress_alert
                 state: "on"
             sequence:
+              - delay:
+                  seconds: 10
               - service: >-
                   {% if states.input_text.notify_service_updates.state is defined %}
                       {% set notify_service = states('input_text.notify_service_updates') %}

--- a/packages/updates_available.yaml
+++ b/packages/updates_available.yaml
@@ -1,4 +1,4 @@
-# Version: 2024.07.1
+# Version: 2024.07.2
 # Updates Available Package
 #
 # Auto update all addons, firmware, core, os.
@@ -153,6 +153,8 @@ automation:
       - condition: state
         entity_id: input_boolean.maintenance_mode
         state: "off"
+      - condition: template
+        value_template: "{{ states.sensor.updates_available.state is defined }}"
     action:
       - choose:
           - conditions:
@@ -255,13 +257,10 @@ automation:
       - condition: state
         entity_id: input_boolean.maintenance_mode
         state: "off"
+      - condition: template
+        value_template: "{{ states.sensor.updates_in_progress.state is defined }}"
     action:
       - choose:
-          - conditions:
-              - condition: state
-                entity_id: sensor.updates_in_progress
-                state: unknown
-            sequence: []
           - conditions:
               - condition: numeric_state
                 entity_id: sensor.updates_in_progress

--- a/packages/updates_available.yaml
+++ b/packages/updates_available.yaml
@@ -1,4 +1,4 @@
-# Version: 2024.07.5
+# Version: 2024.07.6
 # Updates Available Package
 #
 # Auto update all addons, firmware, core, os.
@@ -259,8 +259,6 @@ automation:
       - condition: template
         value_template: "{{ states.sensor.updates_in_progress.state is defined }}"
     action:
-      - wait_template: "{{ states.sensor.updates_in_progress.state is defined }}"
-        continue_on_timeout: false
       - delay:
           seconds: 10
       - choose:

--- a/packages/updates_available.yaml
+++ b/packages/updates_available.yaml
@@ -1,4 +1,4 @@
-# Version: 2024.07.2
+# Version: 2024.07.3
 # Updates Available Package
 #
 # Auto update all addons, firmware, core, os.
@@ -250,7 +250,6 @@ automation:
     trigger:
       - platform: state
         entity_id: sensor.updates_in_progress
-        for: 00:00:10
       - platform: homeassistant
         event: start
     condition:
@@ -260,6 +259,8 @@ automation:
       - condition: template
         value_template: "{{ states.sensor.updates_in_progress.state is defined }}"
     action:
+      - delay:
+          seconds: 10
       - choose:
           - conditions:
               - condition: numeric_state

--- a/packages/updates_available.yaml
+++ b/packages/updates_available.yaml
@@ -35,12 +35,6 @@ script:
             {% set name = 'updates_available.yaml' %}
             {{ url + account + path + name }}
 
-group:
-  turn_off_automations:
-    entities:
-      - automation.updates_available
-      - automation.updates_in_progress
-
 template:
   - trigger:
       - platform: time_pattern

--- a/packages/updates_available.yaml
+++ b/packages/updates_available.yaml
@@ -1,4 +1,4 @@
-# Version: 2024.07.4
+# Version: 2024.07.5
 # Updates Available Package
 #
 # Auto update all addons, firmware, core, os.
@@ -259,6 +259,10 @@ automation:
       - condition: template
         value_template: "{{ states.sensor.updates_in_progress.state is defined }}"
     action:
+      - wait_template: "{{ states.sensor.updates_in_progress.state is defined }}"
+        continue_on_timeout: false
+      - delay:
+          seconds: 10
       - choose:
           - conditions:
               - condition: numeric_state
@@ -266,8 +270,6 @@ automation:
                 above: "0"
                 below: "2"
             sequence:
-              - delay:
-                  seconds: 10
               - service: >-
                   {% if states.input_text.notify_service_updates.state is defined %}
                       {% set notify_service = states('input_text.notify_service_updates') %}
@@ -292,8 +294,6 @@ automation:
                 entity_id: sensor.updates_in_progress
                 above: "1"
             sequence:
-              - delay:
-                  seconds: 10
               - service: >-
                   {% if states.input_text.notify_service_updates.state is defined %}
                       {% set notify_service = states('input_text.notify_service_updates') %}
@@ -321,8 +321,6 @@ automation:
                 entity_id: input_boolean.update_in_progress_alert
                 state: "on"
             sequence:
-              - delay:
-                  seconds: 10
               - service: >-
                   {% if states.input_text.notify_service_updates.state is defined %}
                       {% set notify_service = states('input_text.notify_service_updates') %}

--- a/packages/windows_and_doors.yaml
+++ b/packages/windows_and_doors.yaml
@@ -1,9 +1,9 @@
-# Version: 2024.06.1
+# Version: 2024.07.1
 # Open Windows Package
 # This package create a sensor with number of open windows
 #
-# If you want to exlcude entities create an imput select helper named: " Ignored Doors" 
-# for doors or " Ignored Windows" for windows
+# If you want to exlcude entities create an imput select helper named: "𐃏 Ignored Doors" 
+# for doors or "𐃏 Ignored Windows" for windows
 # and add all entity id's that you want to exclude as options.
 #
 


### PR DESCRIPTION
Change conditions on automations to remove warnings when the packages are reloaded