### PR TITLE
Include unknown state in unavailable entities and sensors

### DIFF
--- a/packages/server.yaml
+++ b/packages/server.yaml
@@ -1,6 +1,6 @@
 # ==================================================================================
 # Package: Server Monitor
-# Version: 2026.07.1
+# Version: 2026.08.1
 # Description:
 #   Monitors server health, handles updates, and manages maintenance modes.
 #   Features a centralized global notification engine with parallel execution.
@@ -254,16 +254,21 @@ automation:
           level: ERROR
     conditions:
       - condition: template
-        value_template: '{{ "Error sending message" in trigger.event.data.message[0] }}'
+        value_template: >-
+          {{
+            "Error sending message" in trigger.event.data.message[0]
+            or ("Error executing script" in trigger.event.data.message[0] 
+            and "notify" in trigger.event.data.message[0])
+          }}
         enabled: true
     actions:
       - action: persistent_notification.create
         data:
           message: |
             ⚠️ A apărut o problemă la trimiterea unei notificari. Anunță echipa tehnică! 
-          
+
             ℹ️ Detalii problemă: 
-            {{ trigger.event.data.message }}
+            {{ trigger.event.data.message[0] }}
 
           title: Nu s-a putut trimite notificarea!
           notification_id: failed_notification
@@ -283,7 +288,12 @@ automation:
         value_template: '{{ "homeassistant.components.automation" in trigger.event.data.name }}'
         enabled: true
       - condition: template
-        value_template: '{{ "failed_automation" not in trigger.event.data.message[0] and "Failed Automation" not in trigger.event.data.message[0] }}'
+        value_template: >-
+          {{
+            "failed_automation" not in trigger.event.data.message[0]
+            and "Failed Automation" not in trigger.event.data.message[0]
+            and "HealthChecks" not in trigger.event.data.message[0]
+          }}
     actions:
       - action: persistent_notification.create
         data:

--- a/packages/unavailable_entities.yaml
+++ b/packages/unavailable_entities.yaml
@@ -1,6 +1,6 @@
 # ==================================================================================
 # Package: Unavailable Entities Monitor
-# Version: 2026.07.1
+# Version: 2026.08.1
 # Description:
 #   Monitors devices and sensors for 'unavailable' or 'none' states.
 #   Routes all alerts through the centralized global notification engine.
@@ -51,7 +51,7 @@ template:
             |selectattr('domain','in',['sensor','binary_sensor'])
             |selectattr('attributes.device_class','defined')
             |selectattr('attributes.device_class','in',['temperature','energy','window','door','opening'])
-            |selectattr('state', 'in', ['unavailable','none'])
+            |selectattr('state', 'in', ['unavailable', 'unknown', 'none'])
             |rejectattr('entity_id','in', ignored )
             |list|count
           }}
@@ -63,7 +63,7 @@ template:
               |selectattr('domain','in',['sensor','binary_sensor'])
               |selectattr('attributes.device_class','defined')
               |selectattr('attributes.device_class','in',['temperature','energy','window','door','opening'])
-              |selectattr('state', 'in', ['unavailable','none'])
+              |selectattr('state', 'in', ['unavailable', 'unknown', 'none'])
               |rejectattr('entity_id','in', ignored ) 
             %}
               {% set dev_name = device_attr(entity.entity_id, 'name_by_user') or device_attr(entity.entity_id, 'name') or '' %}
@@ -96,7 +96,7 @@ template:
           {% set ignored = label_entities('ignore') %}
           {{ states
             |selectattr('domain','in',['switch','light','cover','climate','camera','lock','remote'])
-            |selectattr('state','in',['unavailable','none'])
+            |selectattr('state','in',['unavailable', 'unknown', 'none'])
             |rejectattr('entity_id','in', ignored )
             |list|count
           }}
@@ -106,7 +106,7 @@ template:
             {% set ns = namespace(results=[]) %}
             {% for entity in states
               |selectattr('domain','in',['switch','light','cover','climate','camera','lock','remote'])
-              |selectattr('state','in',['unavailable','none'])
+              |selectattr('state','in',['unavailable', 'unknown', 'none'])
               |rejectattr('entity_id','in', ignored )
             %}
               {% set dev_name = device_attr(entity.entity_id, 'name_by_user') or device_attr(entity.entity_id, 'name') or '' %}


### PR DESCRIPTION
Updated the version number and modified state checks to include 'unknown' as a valid state.